### PR TITLE
create buildkite plugin for atlas

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,4 +14,4 @@ steps:
   - label: ":sparkles: Lint"
     plugins:
       plugin-linter#v3.2.0:
-        id: docker-login
+        id: datumforge/atlas

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Buildkite Plugin Template
+# Atlas Buildkite Plugin 
 
-Check the [buildkite organization](https://github.com/buildkite-plugins) or [website](https://buildkite.com/plugins) to see if your plugin already exists or we can contribute to it !
-
-Be sure to update this readme with your plugin information after using the template repository - for more info checkout Buildkite's documentation [here](https://buildkite.com/docs/plugins)
+Buildkite plugin that will lint and migrate atlas db schemas. 
 
 ## Example
 
@@ -12,11 +10,17 @@ Add the following to your `pipeline.yml`:
 
 ```yml
 steps:
-  - command: ls
-    plugins:
-      - a-github-user/file-counter#v1.0.0:
-          pattern: '*.md'
+  - plugins:
+      - datumforge/atlas#v0.0.1:
+          dir: file://db/migrations
+          project: datum
+          dev-url: sqlite://dev?mode=memory
+          step: all
 ```
+
+## Environment Variables
+
+The `ATLAS_CLOUD_TOKEN` is required to be set in the environment before the plugin can run
 
 ## Developing
 
@@ -32,3 +36,11 @@ To run the tests:
 ```shell
 task test
 ```
+
+## Contributing
+
+1. Fork the repo
+2. Make the changes
+3. Run the tests
+4. Commit and push your changes
+5. Send a pull request

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Atlas Buildkite Plugin 
 
-Buildkite plugin that will lint and migrate atlas db schemas. 
+Buildkite plugin that will `lint` and `migrate` [atlas](https://atlasgo.io/cloud/) db schemas
 
 ## Example
-
-Provide an example of using this plugin, like so:
 
 Add the following to your `pipeline.yml`:
 
@@ -23,8 +21,6 @@ steps:
 The `ATLAS_CLOUD_TOKEN` is required to be set in the environment before the plugin can run
 
 ## Developing
-
-Provide examples on how to modify and test, e.g.:
 
 To run the linter:
 ```shell

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,7 @@
-
 services:
-# You need to update this for your plugin name / location
   lint:
     image: buildkite/plugin-linter
-    command: ['--id', 'a-github-user/file-counter']
+    command: [ '--id', 'datumforge/atlas' ]
     volumes:
       - ".:/plugin:ro"
   tests:

--- a/hooks/command
+++ b/hooks/command
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -o errexit # script exits when a command fails == set -e
+set -o nounset # script exits when tries to use undeclared variables == set -u
+set -o pipefail # causes pipelines to retain / set the last non-zero status
+
+default_branch=${BUILDKITE_PLUGIN_ATLAS_DEFAULT_BRANCH:-${BUILDKITE_PIPELINE_DEFAULT_BRANCH}}
+dev_url=${BUILDKITE_PLUGIN_ATLAS_DEV_URL}
+project=${BUILDKITE_PLUGIN_ATLAS_PROJECT}
+dir=${BUILDKITE_PLUGIN_ATLAS_DIR}
+step=${BUILDKITE_PLUGIN_ATLAS_STEP:-lint}
+
+# Lint and Validate
+if [ "${step}" = "lint" ] || [ "${step}" = "all" ]; then
+    echo +++ :database: lint
+    atlas migrate lint --dev-url "${dev_url}" --dir "${dir}" 
+    atlas migrate validate --dev-url "${dev_url}" --dir "${dir}"
+fi
+
+# Migrate
+if [ "${step}" = "migrate" ] || [ "${step}" = "all" ]; then
+    echo +++ :rocket: migrate
+    if [ "${BUILDKITE_BRANCH}" = "${default_branch}" ]; then
+        atlas migrate push "${project}" --dev-url "${dev_url}" --dir "${dir}"
+    else 
+        echo not pushing migration, not running against "${default_branch}" branch
+    fi
+fi
+
+exit 0

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -o errexit # script exits when a command fails == set -e
-set -o nounset # script exits when tries to use undeclared variables == set -u
-set -o xtrace # trace what's executed == set -x (useful for debugging)
-set -o pipefail # causes pipelines to retain / set the last non-zero status

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,3 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o errexit # script exits when a command fails == set -e
+set -o nounset # script exits when tries to use undeclared variables == set -u
+set -o pipefail # causes pipelines to retain / set the last non-zero status
+
+# Install atlas, if not available
+which atlas || (curl -sSf https://atlasgo.sh | sh -s -- -y)
+
+# Login to atlas 
+atlas login --token "${ATLAS_CLOUD_TOKEN}"
+
+exit 0

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,14 +1,24 @@
 ---
-name: your name
-description: what your plugin does
+name: Atlas
+description: Ariga Atlas Database Tool for use with atlasgo.io
 author: Datum
 requirements:
-  - if you have requirements
+  - bash
+  - curl
 configuration:
   properties:
-    propertyname:
+    dir: # The URL of the migration directory to push
+      type: string
+    project: # The name (slug) of the project in Atlas Cloud
+      type: string
+    dev-url:  # The URL of the dev-database to use for analysis
+      type: string
+    default-branch: # Default branch, defaults to `${BUILDKITE_PIPELINE_DEFAULT_BRANCH}`
+      type: string
+    step: # step to run, lint, migrate, all (runs both). defaults to lint
       type: string
   required:
-    - if any properties are required
-  dependencies:
-    dependencyname: [dep]
+    - dir
+    - project
+    - dev-url
+  additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -3,8 +3,8 @@
 load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment the following line to debug stub failures
-export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
-export WHICH_STUB_DEBUG=/dev/tty
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+# export WHICH_STUB_DEBUG=/dev/tty
 
 @test "default step" {
   export BUILDKITE_PIPELINE_DEFAULT_BRANCH="main"
@@ -130,4 +130,42 @@ export WHICH_STUB_DEBUG=/dev/tty
 
   unstub atlas
 }
+
+@test "missing project" {
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="main"
+  export BUILDKITE_BRANCH="meow"
+  export BUILDKITE_PLUGIN_ATLAS_DEV_URL="sqlite://dev?mode=memory&_fk=1"
+  export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial " BUILDKITE_PLUGIN_ATLAS_PROJECT: unbound variable"
+}
+
+@test "missing dir" {
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="main"
+  export BUILDKITE_BRANCH="meow"
+  export BUILDKITE_PLUGIN_ATLAS_DEV_URL="sqlite://dev?mode=memory&_fk=1"
+  export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial " BUILDKITE_PLUGIN_ATLAS_DIR: unbound variable"
+}
+
+@test "missing url" {
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="main"
+  export BUILDKITE_BRANCH="meow"
+  export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
+  export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial " BUILDKITE_PLUGIN_ATLAS_DEV_URL: unbound variable"
+}
+
+
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+
+load "$BATS_PLUGIN_PATH/load.bash"
+
+# Uncomment the following line to debug stub failures
+export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+export WHICH_STUB_DEBUG=/dev/tty
+
+@test "default step" {
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="main"
+  export BUILDKITE_BRANCH="funk"
+  export BUILDKITE_PLUGIN_ATLAS_DEV_URL="sqlite://dev?mode=memory&_fk=1"
+  export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
+  export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
+
+  stub atlas \
+    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo lint' \
+    'migrate validate --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo validate' \
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "+++ :database: lint"
+  assert_output --partial "lint"
+  assert_output --partial "validate"
+
+  unstub atlas
+}
+
+@test "lint only step" {
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="main"
+  export BUILDKITE_BRANCH="funk"
+  export BUILDKITE_PLUGIN_ATLAS_DEV_URL="sqlite://dev?mode=memory&_fk=1"
+  export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
+  export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
+  export BUILDKITE_PLUGIN_ATLAS_STEP="lint"
+
+  stub atlas \
+    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo lint' \
+    'migrate validate --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo validate' \
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "+++ :database: lint"
+  assert_output --partial "lint"
+  assert_output --partial "validate"
+
+  unstub atlas
+}
+
+@test "migrate only step, on default branch" {
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="main"
+  export BUILDKITE_BRANCH="main"
+  export BUILDKITE_PLUGIN_ATLAS_DEV_URL="sqlite://dev?mode=memory&_fk=1"
+  export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
+  export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
+  export BUILDKITE_PLUGIN_ATLAS_STEP="migrate"
+
+  stub atlas \
+    'migrate push $BUILDKITE_PLUGIN_ATLAS_PROJECT --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo push' \
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "push"
+
+  unstub atlas
+}
+
+@test "migrate only step, on non-default" {
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="main"
+  export BUILDKITE_BRANCH="meow"
+  export BUILDKITE_PLUGIN_ATLAS_DEV_URL="sqlite://dev?mode=memory&_fk=1"
+  export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
+  export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
+  export BUILDKITE_PLUGIN_ATLAS_STEP="migrate"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "not pushing migration"
+}
+
+@test "do it all on main" {
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="main"
+  export BUILDKITE_BRANCH="main"
+  export BUILDKITE_PLUGIN_ATLAS_DEV_URL="sqlite://dev?mode=memory&_fk=1"
+  export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
+  export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
+  export BUILDKITE_PLUGIN_ATLAS_STEP="all"
+
+  stub atlas \
+    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo lint' \
+    'migrate validate --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo validate' \
+    'migrate push $BUILDKITE_PLUGIN_ATLAS_PROJECT --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo push' \
+
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "+++ :database: lint"
+  assert_output --partial "lint"
+  assert_output --partial "validate"
+  assert_output --partial "push"
+
+  unstub atlas
+}
+
+@test "do it all, but its not main" {
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="main"
+  export BUILDKITE_BRANCH="meow"
+  export BUILDKITE_PLUGIN_ATLAS_DEV_URL="sqlite://dev?mode=memory&_fk=1"
+  export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
+  export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
+  export BUILDKITE_PLUGIN_ATLAS_STEP="all"
+
+  stub atlas \
+    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo lint' \
+    'migrate validate --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo validate' \
+
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "+++ :database: lint"
+  assert_output --partial "lint"
+  assert_output --partial "validate"
+  assert_output --partial "not pushing migration"
+
+  unstub atlas
+}
+

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -1,3 +1,0 @@
-#!/usr/bin/env bats
-
-PROJECT_DIR=$(cd "${BATS_TEST_DIRNAME}/.." && pwd)

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load "$BATS_PLUGIN_PATH/load.bash"
+
+# Uncomment the following line to debug stub failures
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+# export WHICH_STUB_DEBUG=/dev/tty
+
+@test "log in to atlas when installed" {
+  export ATLAS_CLOUD_TOKEN="testtoken"
+
+  stub which 'atlas : echo /usr/bin/atlas'
+
+  stub atlas \
+    'login --token $ATLAS_CLOUD_TOKEN : echo You are now connected to meow on Atlas Cloud'
+
+  run "$PWD/hooks/pre-checkout"
+
+  assert_success
+  assert_output --partial "/usr/bin/atlas"
+  assert_output --partial "connected"
+
+  unstub which
+  unstub atlas
+}


### PR DESCRIPTION
buildkite plugin to run lint + migrate against atlas cloud. 

Example run against the `datum` repo can be found: https://buildkite.com/datum/test-atlas-plugin-test-in-datum/builds/23#

partially addresses: https://github.com/datumforge/datum/issues/112