### PR TITLE
Add annotations for the linter

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,7 @@ steps:
     plugins:
       docker-compose#v4.16.0:
         run: tests
+        cli-version: 2
 
   - label: ":sparkles: Lint"
     plugins:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -4,7 +4,7 @@ tasks:
   install:
     desc: install packages required for working with this repo
     cmds:
-      - "brew install shellcheck"
+      - brew install shellcheck
   
   shellcheck:
     desc: shellcheck

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,11 +1,29 @@
 version: "3"
 
 tasks:
+  install:
+    desc: install packages required for working with this repo
+    cmds:
+      - "brew install shellcheck"
+  
+  shellcheck:
+    desc: shellcheck
+    cmds: 
+      - shellcheck hooks/** scripts/**
+
   lint:
     desc: runs the buildkite compose linter
     cmds:
       - docker compose run --rm lint
+
   test:
     desc: runs the buildkite plugin tester
     cmds:
       - docker compose run --rm tests
+
+  ci: 
+    desc: runs all the commands that will be run in CI 
+    cmds:
+      - task: shellcheck
+      - task: lint
+      - task: test

--- a/hooks/command
+++ b/hooks/command
@@ -37,17 +37,17 @@ function main() {
             result=1
             echo -e  ":scream_cat: errors found\n" | buildkite-agent annotate --context "atlas" --style "error" --append
             echo -e  "**Errors**:\n" | buildkite-agent annotate --context "atlas" --append
-            echo -e "$(echo "$error_results" |jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )')\n" | buildkite-agent annotate --context "atlas" --append 
+            echo -e "$(echo "$error_results" |jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )')\n\n" | buildkite-agent annotate --context "atlas" --append 
             if [[ "$warning_results" != ""&& "$warning_results" != "null" ]]; then
             echo -e  "**Warnings**:\n" | buildkite-agent annotate --context "atlas" --append
-            echo -e "$(echo "$warning_results" |jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )')\n" | buildkite-agent annotate --context "atlas" --append 
+            echo -e "$(echo "$warning_results" |jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )')\n\n" | buildkite-agent annotate --context "atlas" --append 
             fi
         elif [[ "$warning_results" != "" && "$warning_results" != "null" ]]; then
             # do not error on warnings
             result=0
             echo -e  ":smirk_cat: warnings found\n" | buildkite-agent annotate --context "atlas" --style "warning" --append
             echo -e  "**Warnings**:\n" | buildkite-agent annotate --context "atlas" --append
-            echo -e "$(echo "$warning_results" |jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )')\n" | buildkite-agent annotate --context "atlas" --append 
+            echo -e "$(echo "$warning_results" |jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )')\n\n" | buildkite-agent annotate --context "atlas" --append 
         else 
             result=0
             echo -e  ":heart_eyes_cat: no errors found, congrats!\n"| buildkite-agent annotate --context "atlas" --style "success"  --append

--- a/hooks/command
+++ b/hooks/command
@@ -36,15 +36,15 @@ function main() {
         if [[ "$error_results" != "" && "$error_results" != "null" ]]; then
             result=1
             echo -e  ":scream_cat: errors found\n" | buildkite-agent annotate --context "atlas" --style "error" --append
-            echo -e "\`\`\`term\n $(echo "$error_results" | jq) \n\`\`\`" | buildkite-agent annotate --context "atlas" --append 
+            echo -e "$(echo "$error_results" |jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )')" | buildkite-agent annotate --context "atlas" --append 
             if [[ "$warning_results" != ""&& "$warning_results" != "null" ]]; then
-                echo -e "\`\`\`term\n $(echo "$warning_results" | jq) \n\`\`\`" | buildkite-agent annotate --context "atlas"  --append
+            echo -e "$(echo "$warning_results" |jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )')" | buildkite-agent annotate --context "atlas" --append 
             fi
         elif [[ "$warning_results" != "" && "$warning_results" != "null" ]]; then
             # do not error on warnings
             result=0
             echo -e  ":smirk_cat: warnings found\n" | buildkite-agent annotate --context "atlas" --style "warning" --append
-            echo -e "\`\`\`term\n $(echo "$warning_results" | jq) \n\`\`\`" | buildkite-agent annotate --context "atlas" --append
+            echo -e "$(echo "$warning_results" |jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )')" | buildkite-agent annotate --context "atlas" --append 
         else 
             result=0
             echo -e  ":heart_eyes_cat: no errors found, congrats!\n"| buildkite-agent annotate --context "atlas" --style "success"  --append
@@ -96,17 +96,13 @@ function parse_lint_result () {
     | select(.Reports != null) 
     | .Reports 
     | map(select(.Text == "destructive changes detected"))
-    | .[0].Diagnostics
-    | Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )' 
-    )
+    | .[0].Diagnostics')
 
     warning_results=$(echo "$lint_result" | jq '.Files[0] 
     | select(.Reports != null) 
     | .Reports 
     | map(select(.Text == "data dependent changes detected"))
-    | .[0].Diagnostics
-    | Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )' 
-    )
+    | .[0].Diagnostics') 
 
     # Display these in the logs 
     echo "$warning_results" |jq

--- a/hooks/command
+++ b/hooks/command
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -o errexit # script exits when a command fails == set -e
 set -o nounset # script exits when tries to use undeclared variables == set -u
 set -o pipefail # causes pipelines to retain / set the last non-zero status
 
@@ -9,22 +8,102 @@ dev_url=${BUILDKITE_PLUGIN_ATLAS_DEV_URL}
 project=${BUILDKITE_PLUGIN_ATLAS_PROJECT}
 dir=${BUILDKITE_PLUGIN_ATLAS_DIR}
 step=${BUILDKITE_PLUGIN_ATLAS_STEP:-lint}
+debug=${BUILDKITE_PLUGIN_ATLAS_DEBUG:-false}
 
-# Lint and Validate
-if [ "${step}" = "lint" ] || [ "${step}" = "all" ]; then
-    echo +++ :database: lint
-    atlas migrate lint --dev-url "${dev_url}" --dir "${dir}" 
-    atlas migrate validate --dev-url "${dev_url}" --dir "${dir}"
+if [[ "$debug" == "true" ]]; then   
+    set -o xtrace # trace what's executed == set -x (useful for debugging)
 fi
 
-# Migrate
-if [ "${step}" = "migrate" ] || [ "${step}" = "all" ]; then
-    echo +++ :rocket: migrate
-    if [ "${BUILDKITE_BRANCH}" = "${default_branch}" ]; then
-        atlas migrate push "${project}" --dev-url "${dev_url}" --dir "${dir}"
-    else 
-        echo not pushing migration, not running against "${default_branch}" branch
+function main() {
+    local error_results=
+    local warning_results=
+    local url=
+
+    # Lint and Validate
+    if [ "${step}" = "lint" ] || [ "${step}" = "all" ]; then
+        echo +++ :database: lint and validate
+        
+        # Run the lint command with the web client, and output to json
+        lint_result=$(atlas migrate lint --dev-url "${dev_url}" --dir "${dir}" -w --format "{{ json .  }}")
+        result=$?
+
+        # Parse the results to display on the top of the buildkite job
+        lint_result="$lint_result" parse_lint_result
+
+        # Start the annotation
+        echo -e "\`atlas migrate lint\` results: " | buildkite-agent annotate --context atlas
+
+        # Check for error results, warning results, otherwise it was successful
+        if [[ $error_results != "" ]]; then
+            echo -e  ":scream_cat: errors found\n" | buildkite-agent annotate --context "atlas" --style "error" --append
+            echo -e "\`\`\`term\n $(echo "$error_results" | jq) \n\`\`\`" | buildkite-agent annotate --context "atlas" --append 
+            if [[ "$warning_results" != "" ]]; then
+                echo -e "\`\`\`term\n $(echo "$warning_results" | jq) \n\`\`\`" | buildkite-agent annotate --context "atlas"  --append
+            fi
+        elif [[ "$warning_results" != "" ]]; then
+            echo -e  ":smirk_cat: warnings found\n" | buildkite-agent annotate --context "atlas" --style "warning" --append
+            echo -e "\`\`\`term\n $(echo "$warning_results" | jq) \n\`\`\`" | buildkite-agent annotate --context "atlas" --append
+        else 
+            echo -e  ":heart_eyes_cat: no errors found, congrats!\n"| buildkite-agent annotate --context "atlas" --style "success"  --append
+        fi
+
+        echo -e  "See the full report [here]($url)\n" | buildkite-agent annotate --context "atlas" --append
+
+        # Exit early if this failed
+        if [[ $result -ne 0 ]]; then 
+            exit "$result"
+        fi
+
+        # Run validate and exit early, if failed
+        atlas migrate validate --dev-url "${dev_url}" --dir "${dir}"
+        result=$?
+        if [[ $result -ne 0 ]]; then 
+            exit "$result"
+        fi
     fi
-fi
 
-exit 0
+    # Push the migration if the step was enabled
+    if [ "${step}" = "migrate" ] || [ "${step}" = "all" ]; then
+        echo +++ :rocket: push migrations
+        # only push on the default branch
+        if [ "${BUILDKITE_BRANCH}" = "${default_branch}" ]; then
+            atlas migrate push "${project}" --dev-url "${dev_url}" --dir "${dir}"
+            result=$?
+        else 
+            echo not pushing migration, not running against "${default_branch}" branch
+            result=0
+        fi
+    fi
+
+    exit "$result"
+}
+
+
+function parse_lint_result () {  
+    url=$(echo "$lint_result" | jq -r '.URL')
+
+    num_files=$(echo "$lint_result"| jq '.Files | length')
+
+    # There are no files present on a successful run, abort now
+    if [[ $num_files == 0 ]]; then
+        return 
+    fi
+
+    error_results=$(echo "$lint_result" | jq '.Files[0] 
+    | select(.Reports != null) 
+    | .Reports 
+    | map(select(.Text == "destructive changes detected"))
+    | .[0].Diagnostics')
+
+    warning_results=$(echo "$lint_result" | jq '.Files[0] 
+    | select(.Reports != null) 
+    | .Reports 
+    | map(select(.Text == "data dependent changes detected"))
+    | .[0].Diagnostics')
+
+    # Display these in the logs 
+    echo "$warning_results" |jq
+    echo "$error_results" |jq
+}
+
+main

--- a/hooks/command
+++ b/hooks/command
@@ -96,13 +96,17 @@ function parse_lint_result () {
     | select(.Reports != null) 
     | .Reports 
     | map(select(.Text == "destructive changes detected"))
-    | .[0].Diagnostics')
+    | .[0].Diagnostics'
+        | jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )' 
+    )
 
     warning_results=$(echo "$lint_result" | jq '.Files[0] 
     | select(.Reports != null) 
     | .Reports 
     | map(select(.Text == "data dependent changes detected"))
-    | .[0].Diagnostics')
+    | .[0].Diagnostics' 
+    | jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )' 
+    )
 
     # Display these in the logs 
     echo "$warning_results" |jq

--- a/hooks/command
+++ b/hooks/command
@@ -25,7 +25,6 @@ function main() {
         
         # Run the lint command with the web client, and output to json
         lint_result=$(atlas migrate lint --dev-url "${dev_url}" --dir "${dir}" -w --format "{{ json .  }}")
-        result=$?
 
         # Parse the results to display on the top of the buildkite job
         lint_result="$lint_result" parse_lint_result
@@ -34,16 +33,20 @@ function main() {
         echo -e "\`atlas migrate lint\` results: " | buildkite-agent annotate --context atlas
 
         # Check for error results, warning results, otherwise it was successful
-        if [[ $error_results != "" ]]; then
+        if [[ "$error_results" != "" && "$error_results" != "null" ]]; then
+            result=1
             echo -e  ":scream_cat: errors found\n" | buildkite-agent annotate --context "atlas" --style "error" --append
             echo -e "\`\`\`term\n $(echo "$error_results" | jq) \n\`\`\`" | buildkite-agent annotate --context "atlas" --append 
-            if [[ "$warning_results" != "" ]]; then
+            if [[ "$warning_results" != ""&& "$warning_results" != "null" ]]; then
                 echo -e "\`\`\`term\n $(echo "$warning_results" | jq) \n\`\`\`" | buildkite-agent annotate --context "atlas"  --append
             fi
-        elif [[ "$warning_results" != "" ]]; then
+        elif [[ "$warning_results" != "" && "$warning_results" != "null" ]]; then
+            # do not error on warnings
+            result=0
             echo -e  ":smirk_cat: warnings found\n" | buildkite-agent annotate --context "atlas" --style "warning" --append
             echo -e "\`\`\`term\n $(echo "$warning_results" | jq) \n\`\`\`" | buildkite-agent annotate --context "atlas" --append
         else 
+            result=0
             echo -e  ":heart_eyes_cat: no errors found, congrats!\n"| buildkite-agent annotate --context "atlas" --style "success"  --append
         fi
 

--- a/hooks/command
+++ b/hooks/command
@@ -96,16 +96,16 @@ function parse_lint_result () {
     | select(.Reports != null) 
     | .Reports 
     | map(select(.Text == "destructive changes detected"))
-    | .[0].Diagnostics'
-        | jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )' 
+    | .[0].Diagnostics
+    | Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )' 
     )
 
     warning_results=$(echo "$lint_result" | jq '.Files[0] 
     | select(.Reports != null) 
     | .Reports 
     | map(select(.Text == "data dependent changes detected"))
-    | .[0].Diagnostics' 
-    | jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )' 
+    | .[0].Diagnostics
+    | Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )' 
     )
 
     # Display these in the logs 

--- a/hooks/command
+++ b/hooks/command
@@ -36,15 +36,18 @@ function main() {
         if [[ "$error_results" != "" && "$error_results" != "null" ]]; then
             result=1
             echo -e  ":scream_cat: errors found\n" | buildkite-agent annotate --context "atlas" --style "error" --append
-            echo -e "$(echo "$error_results" |jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )')" | buildkite-agent annotate --context "atlas" --append 
+            echo -e  "**Errors**:\n" | buildkite-agent annotate --context "atlas" --append
+            echo -e "$(echo "$error_results" |jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )')\n" | buildkite-agent annotate --context "atlas" --append 
             if [[ "$warning_results" != ""&& "$warning_results" != "null" ]]; then
-            echo -e "$(echo "$warning_results" |jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )')" | buildkite-agent annotate --context "atlas" --append 
+            echo -e  "**Warnings**:\n" | buildkite-agent annotate --context "atlas" --append
+            echo -e "$(echo "$warning_results" |jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )')\n" | buildkite-agent annotate --context "atlas" --append 
             fi
         elif [[ "$warning_results" != "" && "$warning_results" != "null" ]]; then
             # do not error on warnings
             result=0
             echo -e  ":smirk_cat: warnings found\n" | buildkite-agent annotate --context "atlas" --style "warning" --append
-            echo -e "$(echo "$warning_results" |jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )')" | buildkite-agent annotate --context "atlas" --append 
+            echo -e  "**Warnings**:\n" | buildkite-agent annotate --context "atlas" --append
+            echo -e "$(echo "$warning_results" |jq -r '"Position | Text | Code", "---| --- |----", (.[] | "\(.Pos) | \(.Text)| \(.Code)" )')\n" | buildkite-agent annotate --context "atlas" --append 
         else 
             result=0
             echo -e  ":heart_eyes_cat: no errors found, congrats!\n"| buildkite-agent annotate --context "atlas" --style "success"  --append

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -7,6 +7,9 @@ set -o pipefail # causes pipelines to retain / set the last non-zero status
 # Install atlas, if not available
 which atlas || (curl -sSf https://atlasgo.sh | sh -s -- -y)
 
+# Install jq, if not available
+which jq || (apt-get install jq)
+
 # Login to atlas 
 atlas login --token "${ATLAS_CLOUD_TOKEN}"
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -17,6 +17,8 @@ configuration:
       type: string
     step: # step to run, lint, migrate, all (runs both). defaults to lint
       type: string
+    debug: 
+      type: string
   required:
     - dir
     - project

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -14,7 +14,7 @@ load "$BATS_PLUGIN_PATH/load.bash"
   export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
 
   stub atlas \
-    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo lint' \
+    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR -w --format "{{ json .  }}" : echo lint' \
     'migrate validate --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo validate' \
 
   run "$PWD/hooks/command"
@@ -36,13 +36,13 @@ load "$BATS_PLUGIN_PATH/load.bash"
   export BUILDKITE_PLUGIN_ATLAS_STEP="lint"
 
   stub atlas \
-    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo lint' \
+    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR -w --format "{{ json .  }}" : echo lint' \
     'migrate validate --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo validate' \
 
   run "$PWD/hooks/command"
 
   assert_success
-  assert_output --partial "+++ :database: lint"
+  assert_output --partial "+++ :database: lint and validate"
   assert_output --partial "lint"
   assert_output --partial "validate"
 
@@ -91,7 +91,7 @@ load "$BATS_PLUGIN_PATH/load.bash"
   export BUILDKITE_PLUGIN_ATLAS_STEP="all"
 
   stub atlas \
-    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo lint' \
+    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR -w --format "{{ json .  }}" : echo lint' \
     'migrate validate --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo validate' \
     'migrate push $BUILDKITE_PLUGIN_ATLAS_PROJECT --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo push' \
 
@@ -102,6 +102,7 @@ load "$BATS_PLUGIN_PATH/load.bash"
   assert_output --partial "+++ :database: lint"
   assert_output --partial "lint"
   assert_output --partial "validate"
+  assert_output --partial "+++ :rocket: push"
   assert_output --partial "push"
 
   unstub atlas
@@ -116,7 +117,7 @@ load "$BATS_PLUGIN_PATH/load.bash"
   export BUILDKITE_PLUGIN_ATLAS_STEP="all"
 
   stub atlas \
-    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo lint' \
+    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR -w --format "{{ json .  }}" : echo lint' \
     'migrate validate --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo validate' \
 
 
@@ -126,6 +127,7 @@ load "$BATS_PLUGIN_PATH/load.bash"
   assert_output --partial "+++ :database: lint"
   assert_output --partial "lint"
   assert_output --partial "validate"
+  assert_output --partial "+++ :rocket: push"
   assert_output --partial "not pushing migration"
 
   unstub atlas

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -10,6 +10,7 @@ load "$BATS_PLUGIN_PATH/load.bash"
   export ATLAS_CLOUD_TOKEN="testtoken"
 
   stub which 'atlas : echo /usr/bin/atlas'
+  stub which 'jq : echo /usr/bin/jq'
 
   stub atlas \
     'login --token $ATLAS_CLOUD_TOKEN : echo You are now connected to meow on Atlas Cloud'
@@ -18,6 +19,7 @@ load "$BATS_PLUGIN_PATH/load.bash"
 
   assert_success
   assert_output --partial "/usr/bin/atlas"
+  assert_output --partial "/usr/bin/jq"
   assert_output --partial "connected"
 
   unstub which


### PR DESCRIPTION
- Adds success, warning, or error annotations for the lint step
- Adds `shellcheck` to the `taskfile`

Formatting Example: 
<img width="1189" alt="image" src="https://github.com/datumforge/atlas-buildkite-plugin/assets/147884153/ba48d7a0-c6df-4470-a73d-4a3a73438bd1">



Example runs against `datum` repo (isolated against just the `lint` job)
failure: https://buildkite.com/datum/datum/builds/2153
warning: https://buildkite.com/datum/datum/builds/2183
pass: https://buildkite.com/datum/datum/builds/2154

Added the taskfile update to the template repo as well: https://github.com/datumforge/template-buildkite-plugin/pull/6