### PR TITLE
set branch on push + lint

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -10,6 +10,14 @@ dir=${BUILDKITE_PLUGIN_ATLAS_DIR}
 step=${BUILDKITE_PLUGIN_ATLAS_STEP:-lint}
 debug=${BUILDKITE_PLUGIN_ATLAS_DEBUG:-false}
 
+atlas_context=$(cat <<EOF
+{
+    "branch": "$BUILDKITE_BRANCH",
+    "commit": "$BUILDKITE_COMMIT"
+}
+EOF
+)
+
 if [[ "$debug" == "true" ]]; then   
     set -o xtrace # trace what's executed == set -x (useful for debugging)
 fi
@@ -73,7 +81,7 @@ function main() {
         echo +++ :rocket: push migrations
         # only push on the default branch
         if [ "${BUILDKITE_BRANCH}" = "${default_branch}" ]; then
-            atlas migrate push "${project}" --dev-url "${dev_url}" --dir "${dir}"
+            atlas migrate push "${project}" --dev-url "${dev_url}" --dir "${dir}" --context "${atlas_context}"
             result=$?
         else 
             echo not pushing migration, not running against "${default_branch}" branch

--- a/hooks/command
+++ b/hooks/command
@@ -32,7 +32,7 @@ function main() {
         echo +++ :database: lint and validate
         
         # Run the lint command with the web client, and output to json
-        lint_result=$(atlas migrate lint --dev-url "${dev_url}" --dir "${dir}" -w --format "{{ json .  }}")
+        lint_result=$(atlas migrate lint --dev-url "${dev_url}" --dir "${dir}" -w --format "{{ json .  }}" --context "${atlas_context}" ) 
 
         # Parse the results to display on the top of the buildkite job
         lint_result="$lint_result" parse_lint_result

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -12,9 +12,17 @@ load "$BATS_PLUGIN_PATH/load.bash"
   export BUILDKITE_PLUGIN_ATLAS_DEV_URL="sqlite://dev?mode=memory&_fk=1"
   export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
   export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
+  export BUILDKITE_COMMIT="24160da9f34e863b2d8fcc1fe6599d868e19f6b7"
+  export CONTEXT=$(cat <<EOF
+{
+    "branch": "funk",
+    "commit": "24160da9f34e863b2d8fcc1fe6599d868e19f6b7"
+}
+EOF
+)
 
   stub atlas \
-    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR -w --format "{{ json .  }}" : echo lint' \
+    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR -w --format "{{ json .  }}" --context "$CONTEXT" : echo lint' \
     'migrate validate --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo validate' \
 
   run "$PWD/hooks/command"
@@ -34,9 +42,17 @@ load "$BATS_PLUGIN_PATH/load.bash"
   export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
   export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
   export BUILDKITE_PLUGIN_ATLAS_STEP="lint"
+  export BUILDKITE_COMMIT="24160da9f34e863b2d8fcc1fe6599d868e19f6b7"
+  export CONTEXT=$(cat <<EOF
+{
+    "branch": "funk",
+    "commit": "24160da9f34e863b2d8fcc1fe6599d868e19f6b7"
+}
+EOF
+)
 
   stub atlas \
-    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR -w --format "{{ json .  }}" : echo lint' \
+    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR -w --format "{{ json .  }}" --context "$CONTEXT" : echo lint' \
     'migrate validate --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo validate' \
 
   run "$PWD/hooks/command"
@@ -107,7 +123,7 @@ EOF
 )
 
   stub atlas \
-    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR -w --format "{{ json .  }}" : echo lint' \
+    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR -w --format "{{ json .  }}" --context "$CONTEXT" : echo lint' \
     'migrate validate --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo validate' \
     'migrate push $BUILDKITE_PLUGIN_ATLAS_PROJECT --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR --context "$CONTEXT" : echo push' \
 
@@ -131,9 +147,17 @@ EOF
   export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
   export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
   export BUILDKITE_PLUGIN_ATLAS_STEP="all"
+  export BUILDKITE_COMMIT="24160da9f34e863b2d8fcc1fe6599d868e19f6b7"
+  export CONTEXT=$(cat <<EOF
+{
+    "branch": "meow",
+    "commit": "24160da9f34e863b2d8fcc1fe6599d868e19f6b7"
+}
+EOF
+)
 
   stub atlas \
-    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR -w --format "{{ json .  }}" : echo lint' \
+    'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR -w --format "{{ json .  }}" --context "$CONTEXT" : echo lint' \
     'migrate validate --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo validate' \
 
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -56,9 +56,17 @@ load "$BATS_PLUGIN_PATH/load.bash"
   export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
   export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
   export BUILDKITE_PLUGIN_ATLAS_STEP="migrate"
-
+  export BUILDKITE_COMMIT="24160da9f34e863b2d8fcc1fe6599d868e19f6b7"
+  export CONTEXT=$(cat <<EOF
+{
+    "branch": "main",
+    "commit": "24160da9f34e863b2d8fcc1fe6599d868e19f6b7"
+}
+EOF
+)
+  
   stub atlas \
-    'migrate push $BUILDKITE_PLUGIN_ATLAS_PROJECT --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo push' \
+    'migrate push $BUILDKITE_PLUGIN_ATLAS_PROJECT --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR --context "$CONTEXT" : echo push' \
 
   run "$PWD/hooks/command"
 
@@ -89,11 +97,19 @@ load "$BATS_PLUGIN_PATH/load.bash"
   export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
   export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
   export BUILDKITE_PLUGIN_ATLAS_STEP="all"
+  export BUILDKITE_COMMIT="24160da9f34e863b2d8fcc1fe6599d868e19f6b7"
+  export CONTEXT=$(cat <<EOF
+{
+    "branch": "main",
+    "commit": "24160da9f34e863b2d8fcc1fe6599d868e19f6b7"
+}
+EOF
+)
 
   stub atlas \
     'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR -w --format "{{ json .  }}" : echo lint' \
     'migrate validate --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo validate' \
-    'migrate push $BUILDKITE_PLUGIN_ATLAS_PROJECT --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo push' \
+    'migrate push $BUILDKITE_PLUGIN_ATLAS_PROJECT --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR --context "$CONTEXT" : echo push' \
 
 
   run "$PWD/hooks/command"


### PR DESCRIPTION
fixes the issue with pushes that the branch was not set so the last updated time on the migrations was not updated correctly